### PR TITLE
Fix blog index title typo

### DIFF
--- a/IslamicBlogs/Views/Blogs/Index.cshtml
+++ b/IslamicBlogs/Views/Blogs/Index.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    ViewData["Title"] = "Bologs";
+    ViewData["Title"] = "Blogs";
 }
 
 


### PR DESCRIPTION
## Summary
- correct typo in Blogs Index view

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d8117a94832f970741b8bf51a09c